### PR TITLE
777: Make AddDetachedSig ISS_CRIT_CLAIM value configurable

### DIFF
--- a/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -25,7 +25,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
@@ -21,7 +21,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -39,7 +39,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
@@ -26,7 +26,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
@@ -21,7 +21,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -39,7 +39,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
@@ -26,7 +26,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -21,7 +21,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
@@ -39,7 +39,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
@@ -26,7 +26,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
@@ -21,7 +21,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -39,7 +39,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
@@ -26,7 +26,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
@@ -25,7 +25,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
@@ -21,7 +21,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
@@ -39,7 +39,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
@@ -26,7 +26,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
@@ -25,7 +25,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
@@ -21,7 +21,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -39,7 +39,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
@@ -26,7 +26,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
@@ -21,7 +21,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
@@ -20,7 +20,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
@@ -39,7 +39,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
@@ -26,7 +26,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
@@ -21,7 +21,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
@@ -25,7 +25,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
@@ -26,7 +26,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
+++ b/config/7.1.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
@@ -26,7 +26,8 @@
               "routeArgSecretId": "jwt.signer",
               "routeArgKid": "&{ig.ob.aspsp.signing.kid}",
               "routeArgSecretsProvider": "${heap['SecretsProvider-ASPSP']}",
-              "routeArgTrustedAnchor": "openbanking.org.uk"
+              "routeArgTrustedAnchor": "openbanking.org.uk",
+              "obAspspOrgId": "&{ig.ob.aspsp.org.id}"
             }
           }
         },

--- a/config/7.1.0/securebanking/ig/scripts/groovy/AddDetachedSig.groovy
+++ b/config/7.1.0/securebanking/ig/scripts/groovy/AddDetachedSig.groovy
@@ -53,7 +53,6 @@ next.handle(context, request).thenOnResult({ response ->
         critClaims.add(ISS_CRIT_CLAIM);
         critClaims.add(TAN_CRIT_CLAIM);
 
-        //TODO - http://openbanking.org.uk/iss must be extracted from the OB signing certificate of the ASPSP. Currently we don't have open banking certificates on ASPSP side
         String jwt
         try {
             jwt = new JwtBuilderFactory()
@@ -62,7 +61,7 @@ next.handle(context, request).thenOnResult({ response ->
                     .alg(signAlgorithm)
                     .kid(routeArgKid)
                     .header(IAT_CRIT_CLAIM, System.currentTimeMillis() / 1000)
-                    .header(ISS_CRIT_CLAIM, "CN=0015800001041REAAY,organizationIdentifier=PSDGB-OB-Unknown0015800001041REAAY,O=FORGEROCK LIMITED,C=GB")
+                    .header(ISS_CRIT_CLAIM, obAspspOrgId) // For an ASPSP the ISS_CRIT_CLAIM is the OB Issued orgId
                     .header(TAN_CRIT_CLAIM, routeArgTrustedAnchor)
                     .crit(critClaims)
                     .done()


### PR DESCRIPTION
Using configuration: IG_OB_ASPSP_ORG_ID to for the AddDetachedSig ISS_CRIT_CLAIM.

The previous value being configured was wrong, it should be the orgId when an ASPSP is signing the message.

See spec:

> If the issuer is using a signing key lodged with a Trust Anchor, the value is defined by the Trust Anchor and should uniquely 
 identify the PSP.
>
> For example, when using the Open Banking Directory, the value must be:
>
>When issued by a TPP, of the form {{org-id}}/{{software-statement-id}},
>When issued by an ASPSP of the form {{org-id}}


See related PR: https://github.com/SecureApiGateway/sapig-openbanking-uk-developer-envs/pull/37

https://github.com/SecureApiGateway/SecureApiGateway/issues/777