### PR TITLE
1704: Update FAPI-PEP-RS-OB to use 2025.6.0 of openIG

### DIFF
--- a/config/7.3.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.3.0/securebanking/ig/config/dev/config/config.json
@@ -208,7 +208,7 @@
     },
     {
       "name": "JwkSetService",
-      "type": "CaffeineCachingJwkSetService",
+      "type": "CachingJwkSetService",
       "config": {
         "handler": "OBClientHandler",
         "maxCacheEntries": 500,

--- a/config/7.3.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.3.0/securebanking/ig/config/dev/config/config.json
@@ -247,7 +247,6 @@
     },
     {
       "name": "CompactSerializationJwsSigner-RSASSA-PSS",
-      "SHTODO": "MigratedToOpenIG",
       "type": "CompactSerializationJwsSigner",
       "config": {
         "algorithm": "PS256",

--- a/config/7.3.0/securebanking/ig/config/dev/config/config.json
+++ b/config/7.3.0/securebanking/ig/config/dev/config/config.json
@@ -67,6 +67,24 @@
       }
     },
     {
+      "name": "fapiAuditService",
+      "type": "AuditService",
+      "config": {
+        "eventHandlers": [
+          {
+            "class": "org.forgerock.audit.handlers.json.stdout.JsonStdoutAuditEventHandler",
+            "config": {
+              "name": "jsonstdout",
+              "elasticsearchCompatible": false,
+              "topics": [
+                "fapi"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "name": "ReverseProxyHandler",
       "type": "ReverseProxyHandler",
       "capture": [
@@ -82,16 +100,10 @@
       "type": "JwtSession"
     },
     {
-      "name": "SBATFapiInteractionFilterChain",
+      "name": "FAPIRSFilterChain",
       "type": "ChainOfFilters",
-      "comment": "This filter chain will set the x-fapi-interaction-id (if not provided in the request), and also set the transaction context to the x-fapi-interaction-id value. This means that if the 'TransactionIdOutboundFilter' is specified on any handlers used by the chain the x-fapi-interaction-id value will be passed onward in the X-ForgeRock-TransactionId header",
       "config": {
         "filters": [
-          {
-            "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-            "name": "FapiInteractionIdFilter",
-            "type": "FapiInteractionIdFilter"
-          },
           {
             "comment": "Dev filter to log access to the route",
             "name": "RouteAccessLog",
@@ -118,16 +130,6 @@
                 "  })"
               ]
             }
-          },
-          {
-            "name": "FapiInteractionIdTracingFilter",
-            "type": "FapiInteractionIdTracingFilter",
-            "comment": "Copy the x-fapi-interaction-id header to TransactionIdContext"
-          },
-          {
-            "comment": "Log any unhandled exceptions, installed after the FapiTransactionIdFilter so that the txId being logged is set to the x-fapi-interaction-id",
-            "name": "SapiLogAttachedExceptionFilter",
-            "type": "SapiLogAttachedExceptionFilter"
           }
         ]
       }
@@ -214,32 +216,6 @@
       }
     },
     {
-      "name": "ValidateApiClientMtlsCertChain",
-      "type": "ChainOfFilters",
-      "comment": "This filter chain validates the ApiClient's MTLS cert using the Trusted Directory, it first fetches all of the resources it needs to perform the validation",
-      "config": {
-        "filters": [
-          {
-            "comment": "Add ApiClient data to the context attributes.apiClient",
-            "name": "FetchApiClientFilter",
-            "type": "FetchApiClientFilter",
-            "config": {
-              "apiClientService": "IdmApiClientService"
-            }
-          },
-          {
-            "comment": "Validate the MTLS transport cert",
-            "name": "TransportCertValidationFilter",
-            "type": "TransportCertValidationFilter",
-            "config": {
-              "certificateRetriever": "HeaderCertificateRetriever",
-              "transportCertValidator": "TransportCertValidator"
-            }
-          }
-        ]
-      }
-    },
-    {
       "name": "SecretsProvider-AmJWK",
       "type": "SecretsProvider",
       "config": {
@@ -251,13 +227,6 @@
             }
           }
         ]
-      }
-    },
-    {
-      "name": "TransportCertValidator",
-      "type": "DefaultTransportCertValidator",
-      "config": {
-        "validKeyUse": "tls"
       }
     },
     {
@@ -278,23 +247,13 @@
     },
     {
       "name": "CompactSerializationJwsSigner-RSASSA-PSS",
+      "SHTODO": "MigratedToOpenIG",
       "type": "CompactSerializationJwsSigner",
       "config": {
         "algorithm": "PS256",
         "signingKeyId": "jwt.signer",
         "kid": "&{ig.ob.aspsp.signing.kid}",
         "secretsProvider": "SecretsProvider-ASPSP"
-      }
-    },
-    {
-      "name": "ContextCertificateRetriever",
-      "type": "ContextCertificateRetriever"
-    },
-    {
-      "name": "HeaderCertificateRetriever",
-      "type": "HeaderCertificateRetriever",
-      "config": {
-        "certificateHeaderName": "ssl-client-cert"
       }
     },
     {

--- a/config/7.3.0/securebanking/ig/config/prod/config/config.json
+++ b/config/7.3.0/securebanking/ig/config/prod/config/config.json
@@ -55,6 +55,24 @@
       }
     },
     {
+      "name": "fapiAuditService",
+      "type": "AuditService",
+      "config": {
+        "eventHandlers": [
+          {
+            "class": "org.forgerock.audit.handlers.json.stdout.JsonStdoutAuditEventHandler",
+            "config": {
+              "name": "jsonstdout",
+              "elasticsearchCompatible": false,
+              "topics": [
+                "fapi"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "name": "ReverseProxyHandler",
       "type": "ReverseProxyHandler",
       "capture": [
@@ -70,25 +88,36 @@
       "type": "JwtSession"
     },
     {
-      "name": "SBATFapiInteractionFilterChain",
+      "name": "FAPIRSFilterChain",
       "type": "ChainOfFilters",
-      "comment": "This filter chain will set the x-fapi-interaction-id (if not provided in the request), and also set the transaction context to the x-fapi-interaction-id value. This means that if the 'TransactionIdOutboundFilter' is specified on any handlers used by the chain the x-fapi-interaction-id value will be passed onward in the X-ForgeRock-TransactionId header",
       "config": {
         "filters": [
           {
-            "comment": "Add x-fapi-interaction-id header if one was not present in the request",
-            "name": "FapiInteractionIdFilter",
-            "type": "FapiInteractionIdFilter"
-          },
-          {
-            "name": "FapiInteractionIdTracingFilter",
-            "type": "FapiInteractionIdTracingFilter",
-            "comment": "Copy the x-fapi-interaction-id header to TransactionIdContext"
-          },
-          {
-            "comment": "Log any unhandled exceptions, installed after the FapiTransactionIdFilter so that the txId being logged is set to the x-fapi-interaction-id",
-            "name": "SapiLogAttachedExceptionFilter",
-            "type": "SapiLogAttachedExceptionFilter"
+            "comment": "Dev filter to log access to the route",
+            "name": "RouteAccessLog",
+            "type": "ScriptableFilter",
+            "config": {
+              "type": "application/x-groovy",
+              "source": [
+                "import org.forgerock.openig.handler.router.RoutingContext",
+                "import org.forgerock.http.protocol.Header",
+                "import static org.forgerock.json.JsonValue.json",
+                "import static org.forgerock.json.JsonValue.object",
+                "import static org.forgerock.json.JsonValue.field",
+                "JsonValue debug = json(object(",
+                "    field(\"routeId\", context.asContext(RoutingContext.class).getRouteId()), ",
+                "    field(\"URI\", request.getUri()), ",
+                "    field(\"referrer\", request.getHeaders().getFirst(\"Referrer\")), ",
+                "    field(\"x-fapi-interaction-id\", request.getHeaders().getFirst(\"x-fapi-interaction-id\"))))",
+                "logger.debug(\"[RouteAccessLog] ENTER: {}\", debug)",
+                "next.handle(context, request)",
+                "    .then({ response ->",
+                "      logger.debug(\"[RouteAccessLog] EXIT: routeId={}\", context.asContext(RoutingContext.class).getRouteId())",
+                "      //response.getEntity().setJson(debug)",
+                "      return response",
+                "  })"
+              ]
+            }
           }
         ]
       }
@@ -175,32 +204,6 @@
       }
     },
     {
-      "name": "ValidateApiClientMtlsCertChain",
-      "type": "ChainOfFilters",
-      "comment": "This filter chain validates the ApiClient's MTLS cert using the Trusted Directory, it first fetches all of the resources it needs to perform the validation",
-      "config": {
-        "filters": [
-          {
-            "comment": "Add ApiClient data to the context attributes.apiClient",
-            "name": "FetchApiClientFilter",
-            "type": "FetchApiClientFilter",
-            "config": {
-              "apiClientService": "IdmApiClientService"
-            }
-          },
-          {
-            "comment": "Validate the MTLS transport cert",
-            "name": "TransportCertValidationFilter",
-            "type": "TransportCertValidationFilter",
-            "config": {
-              "certificateRetriever": "HeaderCertificateRetriever",
-              "transportCertValidator": "TransportCertValidator"
-            }
-          }
-        ]
-      }
-    },
-    {
       "name": "SecretsProvider-AmJWK",
       "type": "SecretsProvider",
       "config": {
@@ -212,13 +215,6 @@
             }
           }
         ]
-      }
-    },
-    {
-      "name": "TransportCertValidator",
-      "type": "DefaultTransportCertValidator",
-      "config": {
-        "validKeyUse": "tls"
       }
     },
     {
@@ -245,17 +241,6 @@
         "signingKeyId": "jwt.signer",
         "kid": "&{ig.ob.aspsp.signing.kid}",
         "secretsProvider": "SecretsProvider-ASPSP"
-      }
-    },
-    {
-      "name": "ContextCertificateRetriever",
-      "type": "ContextCertificateRetriever"
-    },
-    {
-      "name": "HeaderCertificateRetriever",
-      "type": "HeaderCertificateRetriever",
-      "config": {
-        "certificateHeaderName": "ssl-client-cert"
       }
     },
     {

--- a/config/7.3.0/securebanking/ig/config/prod/config/config.json
+++ b/config/7.3.0/securebanking/ig/config/prod/config/config.json
@@ -196,7 +196,7 @@
     },
     {
       "name": "JwkSetService",
-      "type": "CaffeineCachingJwkSetService",
+      "type": "CachingJwkSetService",
       "config": {
         "handler": "OBClientHandler",
         "maxCacheEntries": 500,

--- a/config/7.3.0/securebanking/ig/routes/routes-service/01-ob-rs-metadata.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/01-ob-rs-metadata.json
@@ -7,8 +7,15 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
+        },
         "FAPIRSFilterChain",
         {
           "comment": "Adjust inbound URL to resource server base URL",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/01-ob-rs-metadata.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/01-ob-rs-metadata.json
@@ -7,8 +7,9 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Adjust inbound URL to resource server base URL",
           "name": "UriPathRewriteFilter-RS",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/10-ob-account-consent.json
@@ -9,10 +9,30 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
+          "config": {
+            "auditService" : "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "accounts"
+            ],
+            "allowedGrantType": "client_credentials",
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
+          }
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Check Open Banking compliant response",
           "name": "ObResponseCheck",
@@ -23,49 +43,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Extracts the access_token from the request header. Uses the resolver to resolve the access_token and validate the token claims. Checks that the token has the scopes required by the filter configuration. Injects the access_token info into the OAuth2Context.",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "accounts"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "comment": "Check certificate-bound OAuth 2.0 bearer tokens presented by clients use the same mTLS-authenticated HTTP connection",
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "name": "token-resolver-1",
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "ValidateApiClientMtlsCertChain",
-        {
           "comment": "Make sure client certificate includes AISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -74,18 +51,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "AISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "client_credentials"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/100-internal-repo.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/100-internal-repo.json
@@ -6,8 +6,9 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "name": "SwitchFilter-RequestRouter",
           "type": "SwitchFilter",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/100-internal-repo.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/100-internal-repo.json
@@ -6,8 +6,15 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
+        },
         "FAPIRSFilterChain",
         {
           "name": "SwitchFilter-RequestRouter",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/11-ob-account-access.json
@@ -12,10 +12,30 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
+          "config": {
+            "auditService" : "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "accounts",
+              "openid"
+            ],
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
+          }
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Ensure OB compliant response",
           "name": "ObResponseCheck",
@@ -47,50 +67,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Extracts the access_token from the request header. Uses the resolver to resolve the access_token and validate the token claims. Checks that the token has the scopes required by the filter configuration. Injects the access_token info into the OAuth2Context.",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "accounts",
-              "openid"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "comment": "Check certificate-bound OAuth 2.0 bearer tokens presented by clients use the same mTLS-authenticated HTTP connection",
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "name": "token-resolver-1",
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "ValidateApiClientMtlsCertChain",
-        {
           "comment": "Ensure ApiClient includesAISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -99,18 +75,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "AISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "authorization_code"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/12-ob-account-access-multiple-routes.json
@@ -12,10 +12,30 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
+          "config": {
+            "auditService" : "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "accounts",
+              "openid"
+            ],
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
+          }
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Ensure OB compliant response",
           "name": "ObResponseCheck",
@@ -47,50 +67,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Extracts the access_token from the request header. Uses the resolver to resolve the access_token and validate the token claims. Checks that the token has the scopes required by the filter configuration. Injects the access_token info into the OAuth2Context.",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "accounts",
-              "openid"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "comment": "Check certificate-bound OAuth 2.0 bearer tokens presented by clients use the same mTLS-authenticated HTTP connection",
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "name": "token-resolver-1",
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "ValidateApiClientMtlsCertChain",
-        {
           "comment": "Ensure ApiClient includesAISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -99,18 +75,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "AISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "authorization_code"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/200-events-admin-api.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/200-events-admin-api.json
@@ -11,8 +11,9 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Ensure the response is Open Banking compliant",
           "name": "ObResponseCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/200-events-admin-api.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/200-events-admin-api.json
@@ -73,7 +73,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Check grant type",
           "name": "Grant Type Verifier",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/200-events-admin-api.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/200-events-admin-api.json
@@ -11,8 +11,15 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
+        },
         "FAPIRSFilterChain",
         {
           "comment": "Ensure the response is Open Banking compliant",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -88,7 +88,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -10,11 +10,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -12,10 +12,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -10,12 +10,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
@@ -8,10 +8,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
@@ -6,12 +6,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
@@ -6,11 +6,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
@@ -83,7 +83,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -89,7 +89,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -13,10 +13,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -11,12 +11,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -11,11 +11,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
@@ -88,7 +88,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
@@ -13,10 +13,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
@@ -11,12 +11,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
@@ -11,11 +11,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
@@ -8,10 +8,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
@@ -6,12 +6,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
@@ -6,11 +6,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
@@ -83,7 +83,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -89,7 +89,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -13,10 +13,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -11,12 +11,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -11,11 +11,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
@@ -88,7 +88,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
@@ -13,10 +13,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
@@ -11,12 +11,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
@@ -11,11 +11,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -8,10 +8,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -6,12 +6,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -6,11 +6,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -83,7 +83,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
@@ -89,7 +89,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
@@ -13,10 +13,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
@@ -11,12 +11,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
@@ -11,11 +11,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
@@ -88,7 +88,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
@@ -13,10 +13,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
@@ -11,12 +11,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
@@ -11,11 +11,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
@@ -8,10 +8,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
@@ -6,12 +6,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
@@ -6,11 +6,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
@@ -83,7 +83,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -89,7 +89,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -13,10 +13,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -11,12 +11,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -11,11 +11,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
@@ -88,7 +88,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
@@ -13,10 +13,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
@@ -11,12 +11,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
@@ -11,11 +11,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
@@ -88,7 +88,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
@@ -10,11 +10,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
@@ -12,10 +12,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
@@ -10,12 +10,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
@@ -8,10 +8,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
@@ -6,12 +6,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
@@ -6,11 +6,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
@@ -83,7 +83,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
@@ -89,7 +89,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
@@ -13,10 +13,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
@@ -11,12 +11,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
@@ -11,11 +11,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
@@ -88,7 +88,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
@@ -13,10 +13,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
@@ -11,12 +11,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
@@ -11,11 +11,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
@@ -88,7 +88,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
@@ -10,11 +10,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
@@ -12,10 +12,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
@@ -10,12 +10,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
@@ -8,10 +8,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
@@ -6,12 +6,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
@@ -6,11 +6,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
@@ -83,7 +83,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -89,7 +89,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -13,10 +13,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -11,12 +11,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -11,11 +11,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
@@ -88,7 +88,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
@@ -13,10 +13,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
@@ -11,12 +11,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
@@ -11,11 +11,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
@@ -8,10 +8,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
@@ -6,12 +6,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
@@ -6,11 +6,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
@@ -83,7 +83,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
@@ -8,10 +8,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
@@ -6,12 +6,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
@@ -6,11 +6,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
@@ -83,7 +83,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
@@ -89,7 +89,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
@@ -13,10 +13,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
@@ -11,12 +11,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
@@ -11,11 +11,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
@@ -88,7 +88,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
@@ -13,10 +13,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
@@ -11,12 +11,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
@@ -11,11 +11,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
@@ -8,10 +8,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
@@ -6,12 +6,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
@@ -6,11 +6,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
@@ -83,7 +83,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
@@ -88,7 +88,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
@@ -10,11 +10,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
@@ -12,10 +12,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
@@ -10,12 +10,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
@@ -89,7 +89,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
@@ -13,10 +13,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
@@ -11,12 +11,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
@@ -11,11 +11,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
@@ -88,7 +88,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
@@ -13,10 +13,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
@@ -11,12 +11,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
@@ -11,11 +11,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/66-ob-funds-confirmation-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/66-ob-funds-confirmation-consent.json
@@ -6,12 +6,13 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Ensure OB compliant response",
           "name": "ObResponseCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/66-ob-funds-confirmation-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/66-ob-funds-confirmation-consent.json
@@ -8,10 +8,6 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
-        },
-        {
           "comment": "FAPI Resource Filter Chain",
           "name": "fapiResourceUnprotectedFilterChain",
           "type": "FapiResourceUnprotectedFilterChain",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/66-ob-funds-confirmation-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/66-ob-funds-confirmation-consent.json
@@ -65,7 +65,6 @@
             }
           }
         },
-        "ValidateApiClientMtlsCertChain",
         {
           "comment": "Ensure ApiClient includes CBPII role",
           "name": "ApiClientRoleCheck",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/66-ob-funds-confirmation-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/66-ob-funds-confirmation-consent.json
@@ -6,11 +6,18 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
         {
           "name": "RouteMetricsFilter",
           "type": "RouteMetricsFilter"
+        },
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
         },
         "FAPIRSFilterChain",
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/67-ob-funds-confirmation-availability.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/67-ob-funds-confirmation-availability.json
@@ -12,10 +12,30 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
+          "config": {
+            "auditService" : "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "fundsconfirmations",
+              "openid"
+            ],
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
+          }
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Ensure OB compliant response",
           "name": "ObResponseCheck",
@@ -47,50 +67,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Extracts the access_token from the request header. Uses the resolver to resolve the access_token and validate the token claims. Checks that the token has the scopes required by the filter configuration. Injects the access_token info into the OAuth2Context.",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "fundsconfirmations",
-              "openid"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "comment": "Check certificate-bound OAuth 2.0 bearer tokens presented by clients use the same mTLS-authenticated HTTP connection",
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "name": "token-resolver-1",
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "ValidateApiClientMtlsCertChain",
-        {
           "comment": "Ensure ApiClient includes CBPII role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -99,18 +75,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "CBPII"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "authorization_code"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/68-ob-aggregated-polling.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/68-ob-aggregated-polling.json
@@ -12,10 +12,28 @@
     "config": {
       "filters": [
         {
-          "name": "RouteMetricsFilter",
-          "type": "RouteMetricsFilter"
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
+          "config": {
+            "auditService" : "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [],
+            "allowedGrantType": "client_credentials",
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
+          }
         },
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "comment": "Ensure OB compliant response",
           "name": "ObResponseCheck",
@@ -60,47 +78,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Extracts the access_token from the request header. Uses the resolver to resolve the access_token and validate the token claims. Checks that the token has the scopes required by the filter configuration. Injects the access_token info into the OAuth2Context.",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "comment": "Check certificate-bound OAuth 2.0 bearer tokens presented by clients use the same mTLS-authenticated HTTP connection",
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "name": "token-resolver-1",
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "ValidateApiClientMtlsCertChain",
-        {
           "comment": "The access token required for accessing the API must have at last one scope of 'allowedScopes'",
           "name": "Token Scopes Verifier",
           "type": "ScriptableFilter",
@@ -109,18 +86,6 @@
             "file": "VerifyAccessTokenScopes.groovy",
             "args": {
               "allowedScopes": ["payments", "accounts", "fundsconfirmations"]
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "client_credentials"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/81-rcs-ui.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/81-rcs-ui.json
@@ -11,8 +11,9 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "name": "SingleSignOnFilter",
           "type": "SingleSignOnFilter",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/81-rcs-ui.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/81-rcs-ui.json
@@ -11,8 +11,15 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
+        },
         "FAPIRSFilterChain",
         {
           "name": "SingleSignOnFilter",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/82-rcs-ui-assets.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/82-rcs-ui-assets.json
@@ -7,8 +7,9 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "name": "SingleSignOnFilter",
           "type": "SingleSignOnFilter",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/82-rcs-ui-assets.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/82-rcs-ui-assets.json
@@ -7,8 +7,15 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
+        },
         "FAPIRSFilterChain",
         {
           "name": "SingleSignOnFilter",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/83-rcs-api.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/83-rcs-api.json
@@ -11,8 +11,9 @@
   "handler": {
     "type": "Chain",
     "config": {
+      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
-        "SBATFapiInteractionFilterChain",
+        "FAPIRSFilterChain",
         {
           "name": "SingleSignOnFilter",
           "type": "SingleSignOnFilter",

--- a/config/7.3.0/securebanking/ig/routes/routes-service/83-rcs-api.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/83-rcs-api.json
@@ -11,8 +11,15 @@
   "handler": {
     "type": "Chain",
     "config": {
-      "SHTODO": "UnprotectedFAPIRSFilterChain",
       "filters": [
+        {
+          "comment": "FAPI Resource Filter Chain",
+          "name": "fapiResourceUnprotectedFilterChain",
+          "type": "FapiResourceUnprotectedFilterChain",
+          "config": {
+            "auditService": "fapiAuditService"
+          }
+        },
         "FAPIRSFilterChain",
         {
           "name": "SingleSignOnFilter",

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,7 @@
 
     <packaging>pom</packaging>
     <name>secure-api-gateway-fapi-pep-rs-ob</name>
-    <description>Gateway (IG) Extensions modules that are used by IG to extend uk spec functionalities for Secure API Gateway
-    </description>
+    <description>Secure API Gateway FAPI PEP RS OB components</description>
     <url>https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-rs-ob.git</url>
     <licenses>
         <license>
@@ -54,13 +53,6 @@
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
     </properties>
 
-    <scm>
-        <connection>scm:git:${project.scm.url}</connection>
-        <developerConnection>scm:git:${project.scm.url}</developerConnection>
-        <url>https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-rs-ob.git</url>
-        <tag>HEAD</tag>
-    </scm>
-
     <dependencyManagement>
         <dependencies>
             <!-- IG BOM -->
@@ -85,6 +77,13 @@
         </dependencies>
     </dependencyManagement>
 
+    <scm>
+        <connection>scm:git:${project.scm.url}</connection>
+        <developerConnection>scm:git:${project.scm.url}</developerConnection>
+        <url>https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-rs-ob.git</url>
+        <tag>HEAD</tag>
+    </scm>
+
     <repositories>
         <repository>
             <id>maven.forgerock.org-community</id>
@@ -107,7 +106,7 @@
         </repository>
         <repository>
             <id>forgerock-internal-releases</id>
-            <name>ForgeRock Internal Releases Repository</name>
+            <name>ForgeRock Private Releases Repository</name>
             <url>https://maven.forgerock.org/artifactory/internal-releases</url>
             <snapshots>
                 <enabled>false</enabled>
@@ -115,6 +114,17 @@
             <releases>
                 <enabled>true</enabled>
             </releases>
+        </repository>
+        <repository>
+        <id>forgerock-internal-snapshots</id>
+        <name>ForgeRock Internal Snapshots Repository</name>
+        <url>https://maven.forgerock.org/artifactory/internal-snapshots</url>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
+        <releases>
+            <enabled>false</enabled>
+        </releases>
         </repository>
     </repositories>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -46,11 +46,11 @@
     </parent>
 
     <properties>
-        <secure-api-gateway.version>4.0.4</secure-api-gateway.version>
-        <openig.version>2024.11.0</openig.version>
+        <secure-api-gateway.version>4.0.5-SNAPSHOT</secure-api-gateway.version>
+        <openig.version>2025.6.0-SNAPSHOT</openig.version>
         <nimbus-jose.version>9.40</nimbus-jose.version>
         <bouncy-castle.version>1.78.1</bouncy-castle.version>
-        <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
+        <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
     </properties>
 
     <scm>

--- a/secure-api-gateway-fapi-pep-rs-ob-docker/Dockerfile
+++ b/secure-api-gateway-fapi-pep-rs-ob-docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-ARG base_image=gcr.io/forgerock-io/ig:2024.11.0
+ARG base_image=gcr.io/forgerock-io/ig/docker-build:2025.6.0-latest-postcommit-fapi
 FROM ${base_image}
 # Switching back to forgerock user, app will run as this
 USER forgerock


### PR DESCRIPTION
Bump  

- secure-api-gateway.version -> 4.0.5-SNAPSHOT
- openig.version -> 2025.6.0-SNAPSHOT
- maven-resources-plugin.version -> 3.3.1
 
Amend config and routes to use 2025.6.0 of openig which included migration of code from SAPIG 

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1704