### PR TITLE
1704: Update FAPI-PEP-RS-OB to use 2025.6.0 of openIG

### DIFF
--- a/config/7.3.0/securebanking/ig/routes/routes-service/200-events-admin-api.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/200-events-admin-api.json
@@ -14,10 +14,29 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService" : "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "accounts",
+              "payments",
+              "fundsconfirmations",
+              "openid"
+            ],
+            "allowedGrantType": "client_credentials",
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -28,61 +47,6 @@
           "config": {
             "type": "application/x-groovy",
             "file": "ObResponseCheck.groovy"
-          }
-        },
-        {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "accounts",
-              "payments",
-              "fundsconfirmations",
-              "openid"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "client_credentials"
-            }
           }
         },
         {

--- a/config/7.3.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/30-ob-payment-consent-funds-confirmation.json
@@ -13,10 +13,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments",
+              "openid"
+            ],
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -48,47 +64,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments",
-              "openid"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -97,18 +72,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "authorization_code"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/31-ob-payment-consent.json
@@ -9,10 +9,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments"
+            ],
+            "allowedGrantType": "client_credentials",
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -44,46 +60,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -92,18 +68,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "client_credentials"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/32-ob-payment-submission.json
@@ -14,10 +14,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments",
+              "openid"
+            ],
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -49,47 +65,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments",
-              "openid"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -98,18 +73,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "authorization_code"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/33-ob-domestic-payments-access.json
@@ -14,10 +14,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments"
+            ],
+            "allowedGrantType": "client_credentials",
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -49,46 +65,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -97,18 +73,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "client_credentials"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/35-ob-scheduled-payment-consent.json
@@ -9,10 +9,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments"
+            ],
+            "allowedGrantType": "client_credentials",
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -44,46 +60,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -92,18 +68,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "client_credentials"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -14,10 +14,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments",
+              "openid"
+            ],
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -49,47 +65,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments",
-              "openid"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -98,18 +73,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "authorization_code"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/37-ob-scheduled-domestic-payments-access.json
@@ -14,10 +14,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments"
+            ],
+            "allowedGrantType": "client_credentials",
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -49,46 +65,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -97,18 +73,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "client_credentials"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/40-ob-domestic-standing-order-consent.json
@@ -9,10 +9,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments"
+            ],
+            "allowedGrantType": "client_credentials",
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -44,46 +60,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -92,18 +68,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "client_credentials"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/41-ob-domestic-standing-orders-submission.json
@@ -14,10 +14,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments",
+              "openid"
+            ],
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -49,47 +65,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments",
-              "openid"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -98,18 +73,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "authorization_code"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/42-ob-domestic-standing-orders-access.json
@@ -14,10 +14,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments"
+            ],
+            "allowedGrantType": "client_credentials",
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -49,46 +65,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -97,18 +73,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "client_credentials"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/45-ob-international-payment-consent.json
@@ -9,10 +9,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments"
+            ],
+            "allowedGrantType": "client_credentials",
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -44,46 +60,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -92,18 +68,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "client_credentials"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/46-ob-international-payment-submission.json
@@ -14,10 +14,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments",
+              "openid"
+            ],
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -49,47 +65,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments",
-              "openid"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -98,18 +73,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "authorization_code"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/47-ob-international-payment-access.json
@@ -14,10 +14,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments"
+            ],
+            "allowedGrantType": "client_credentials",
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -49,46 +65,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -97,18 +73,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "client_credentials"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/48-ob-international-payment-funds-confirmation.json
@@ -13,10 +13,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments",
+              "openid"
+            ],
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -48,47 +64,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments",
-              "openid"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -97,18 +72,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "authorization_code"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/50-ob-international-scheduled-payment-consent.json
@@ -9,10 +9,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments"
+            ],
+            "allowedGrantType": "client_credentials",
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -44,46 +60,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -92,18 +68,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "client_credentials"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/51-ob-international-scheduled-payment-submission.json
@@ -14,10 +14,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments",
+              "openid"
+            ],
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -49,47 +65,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments",
-              "openid"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -98,18 +73,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "authorization_code"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/52-ob-international-scheduled-payment-access.json
@@ -14,10 +14,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments"
+            ],
+            "allowedGrantType": "client_credentials",
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -49,46 +65,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -97,18 +73,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "client_credentials"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/53-ob-international-scheduled-payment-funds-confirmation.json
@@ -13,10 +13,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments",
+              "openid"
+            ],
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -48,47 +64,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments",
-              "openid"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -97,18 +72,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "authorization_code"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/55-ob-international-standing-order-consent.json
@@ -9,10 +9,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments"
+            ],
+            "allowedGrantType": "client_credentials",
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -44,46 +60,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -92,18 +68,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "client_credentials"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/56-ob-international-standing-orders-submission.json
@@ -14,10 +14,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments",
+              "openid"
+            ],
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -49,47 +65,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments",
-              "openid"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -98,18 +73,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "authorization_code"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/57-ob-international-standing-orders-access.json
@@ -14,10 +14,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments"
+            ],
+            "allowedGrantType": "client_credentials",
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -49,46 +65,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -97,18 +73,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "client_credentials"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/58-ob-file-payment-consent.json
@@ -9,10 +9,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments"
+            ],
+            "allowedGrantType": "client_credentials",
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -44,46 +60,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -92,18 +68,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "client_credentials"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/59-ob-file-payment-consent-submission.json
@@ -9,10 +9,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments"
+            ],
+            "allowedGrantType": "client_credentials",
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -44,46 +60,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -92,18 +68,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "client_credentials"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/60-ob-file-payment-submission.json
@@ -14,10 +14,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments",
+              "openid"
+            ],
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -49,47 +65,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments",
-              "openid"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -98,18 +73,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "authorization_code"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/61-ob-file-payment-access.json
@@ -14,10 +14,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments"
+            ],
+            "allowedGrantType": "client_credentials",
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -49,46 +65,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -97,18 +73,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "client_credentials"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/62-ob-domestic-vrp-consent.json
@@ -9,10 +9,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments"
+            ],
+            "allowedGrantType": "client_credentials",
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -44,46 +60,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -92,18 +68,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "client_credentials"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/63-ob-domestic-vrp-funds-confirmation.json
@@ -13,10 +13,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments",
+              "openid"
+            ],
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -48,47 +64,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments",
-              "openid"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -97,18 +72,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "authorization_code"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/64-ob-domestic-vrps-submission.json
@@ -14,10 +14,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments",
+              "openid"
+            ],
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -49,47 +65,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments",
-              "openid"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -98,18 +73,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "authorization_code"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/65-ob-domestic-vrps-access.json
@@ -14,10 +14,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "payments"
+            ],
+            "allowedGrantType": "client_credentials",
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -49,46 +65,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "payments"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includesPISP role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -97,18 +73,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "PISP"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "client_credentials"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/routes/routes-service/66-ob-funds-confirmation-consent.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/66-ob-funds-confirmation-consent.json
@@ -9,10 +9,26 @@
       "filters": [
         {
           "comment": "FAPI Resource Filter Chain",
-          "name": "fapiResourceUnprotectedFilterChain",
-          "type": "FapiResourceUnprotectedFilterChain",
+          "name": "fapiResourceFilterChain",
+          "type": "FapiResourceFilterChain",
           "config": {
-            "auditService": "fapiAuditService"
+            "auditService": "fapiAuditService",
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
+            "scopes": [
+              "fundsconfirmations"
+            ],
+            "allowedGrantType": "client_credentials",
+            "realm": "OpenIG",
+            "accessTokenResolver": {
+              "name": "token-resolver",
+              "type": "StatelessAccessTokenResolver",
+              "config": {
+                "secretsProvider": "SecretsProvider-AmJWK",
+                "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
+                "verificationSecretId": "any.value.in.regex.format"
+              }
+            },
+            "apiClientService": "IdmApiClientService"
           }
         },
         "FAPIRSFilterChain",
@@ -26,46 +42,6 @@
           }
         },
         {
-          "comment": "Extract client certificate thumbprint for cert bound access tokens",
-          "name": "CertificateThumbprintFilter-1",
-          "type": "CertificateThumbprintFilter",
-          "config": {
-            "certificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}",
-            "failureHandler": {
-              "type": "ScriptableHandler",
-              "config": {
-                "type": "application/x-groovy",
-                "file": "ReturnInvalidCnfKeyError.groovy"
-              }
-            }
-          }
-        },
-        {
-          "comment": "Check certificate bound access token",
-          "name": "OAuth2ResourceServerFilter-OB",
-          "type": "OAuth2ResourceServerFilter",
-          "config": {
-            "scopes": [
-              "fundsconfirmations"
-            ],
-            "requireHttps": false,
-            "realm": "OpenIG",
-            "accessTokenResolver": {
-              "type": "ConfirmationKeyVerifierAccessTokenResolver",
-              "config": {
-                "delegate": {
-                  "type": "StatelessAccessTokenResolver",
-                  "config": {
-                    "secretsProvider": "SecretsProvider-AmJWK",
-                    "issuer": "https://&{as.fqdn}/am/oauth2/realms/root/realms/&{am.realm}",
-                    "verificationSecretId": "any.value.in.regex.format"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
           "comment": "Ensure ApiClient includes CBPII role",
           "name": "ApiClientRoleCheck",
           "type": "ScriptableFilter",
@@ -74,18 +50,6 @@
             "file": "ApiClientRoleCheck.groovy",
             "args": {
               "routeArgRole": "CBPII"
-            }
-          }
-        },
-        {
-          "comment": "Check grant type",
-          "name": "Grant Type Verifier",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "GrantTypeVerifier.groovy",
-            "args": {
-              "allowedGrantType": "client_credentials"
             }
           }
         },

--- a/config/7.3.0/securebanking/ig/scripts/groovy/ApiClientRoleCheck.groovy
+++ b/config/7.3.0/securebanking/ig/scripts/groovy/ApiClientRoleCheck.groovy
@@ -1,5 +1,4 @@
-import org.forgerock.http.protocol.*
-import org.forgerock.json.jose.*
+import org.forgerock.openig.fapi.apiclient.ApiClientFapiContext;
 
 // Check transport certificate for roles appropriate to request
 def fapiInteractionId = request.getHeaders().getFirst("x-fapi-interaction-id");
@@ -9,18 +8,21 @@ SCRIPT_NAME = "[ApiClientRoleCheck] (" + fapiInteractionId + ") - ";
 logger.debug(SCRIPT_NAME + "Running...")
 logger.debug(SCRIPT_NAME + "Checking certificate roles for {} request", routeArgRole)
 
-if (!attributes.apiClient){
-  logger.error("FetchApiClientFilter must be run before this script. apiClient needs to exist in the attributes context");
-  return new Response(Status.INTERNAL_SERVER_ERROR)
+def apiClientFapiContext = context.asContext(ApiClientFapiContext.class)
+def apiClientOpt = apiClientFapiContext.getApiClient()
+if (apiClientOpt.isEmpty()) {
+    logger.error("apiClient must be identified before this script - it should exist in the ApiClientFapiContext")
+    return new Response(Status.INTERNAL_SERVER_ERROR)
 }
 
-if (!attributes.apiClient.getRoles().contains(routeArgRole)) {
-  def errorMessage = "client is not authorized to perform role: " + routeArgRole
-  logger.warn(SCRIPT_NAME + "ApiClient.id=" + attributes.apiClient.getOauth2ClientId() + " " + errorMessage)
-  
-  def response = new Response(Status.FORBIDDEN)
-  response.entity = json(object(field("error", errorMessage)))
-  return response
+def apiClient = apiClientOpt.get()
+if (!apiClient.getRoles().contains(routeArgRole)) {
+    def errorMessage = "client is not authorized to perform role: " + routeArgRole
+    logger.warn(SCRIPT_NAME + "ApiClient.id=" + apiClient.getOauth2ClientId() + " " + errorMessage)
+
+    def response = new Response(Status.FORBIDDEN)
+    response.entity = json(object(field("error", errorMessage)))
+    return response
 }
 
 next.handle(context, request)

--- a/config/7.3.0/securebanking/ig/scripts/groovy/ProcessDetachedSig.groovy
+++ b/config/7.3.0/securebanking/ig/scripts/groovy/ProcessDetachedSig.groovy
@@ -373,12 +373,14 @@ def validateIssCritClaim(issCritClaim) {
 }
 
 def apiClient() {
-    def apiClient = attributes.apiClient
-    if (apiClient == null) {
+    def apiClientFapiContext = context.asContext(ApiClientFapiContext.class)
+    def apiClientOpt = apiClientFapiContext.getApiClient()
+    if (apiClientOpt.isEmpty()) {
+        logger.error("apiClient must be identified before this script - it should exist in the ApiClientFapiContext")
         throw new IllegalStateException("Route is configured incorrectly, " + SCRIPT_NAME +
                                                 "requires apiClient context attribute")
     }
-    return apiClient
+    return apiClientOpt.get()
 }
 
 /**

--- a/config/7.3.0/securebanking/ig/scripts/groovy/ProcessDetachedSig.groovy
+++ b/config/7.3.0/securebanking/ig/scripts/groovy/ProcessDetachedSig.groovy
@@ -15,6 +15,7 @@ import org.forgerock.json.jose.jwk.JWKSet
 import org.forgerock.json.jose.jwk.RsaJWK
 import org.forgerock.json.jose.exceptions.FailedToLoadJWKException
 import org.forgerock.json.jose.jwk.store.JwksStore.*
+import org.forgerock.openig.fapi.apiclient.ApiClientFapiContext;
 import com.forgerock.securebanking.uk.gateway.jwks.*
 import java.security.interfaces.RSAPublicKey
 import org.forgerock.util.time.Duration


### PR DESCRIPTION
- [Use proper resource filter on protected routes](https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-rs-ob/pull/597/commits/381af69bb88125925bbe8a661d5c87b1b8bae1a3)
- [Fix ApiClientRoleCheck script where apiClient is checked](https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-rs-ob/pull/597/commits/de0866b848d18a21e2808603add1d22a8757dd4b)
- [1704: Add missing import to ProcessDetachedSig script](https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-rs-ob/pull/597/commits/8def2ae78e323cf7152e70eac76ce623691c1cd9)

Made a new PR with existing branch names so that the issue can be tracked

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1704