### PR TITLE
OPENIG-9515 Introduce RCS API client error tranform filter

### DIFF
--- a/config/7.3.0/securebanking/ig/routes/routes-service/83-rcs-api.json
+++ b/config/7.3.0/securebanking/ig/routes/routes-service/83-rcs-api.json
@@ -71,6 +71,11 @@
               "referer"
             ]
           }
+        },
+        {
+          "name": "RepoApiErrorTransformFilter",
+          "type": "RepoApiErrorTransformFilter",
+          "comment": "Ensure error responses match OAuth2 standard"
         }
       ],
       "handler": "FRReverseProxyHandler"

--- a/secure-api-gateway-ig-extensions-ob/src/main/java/com/forgerock/sapi/gateway/ob/SecureApiGatewayObClassAliasResolver.java
+++ b/secure-api-gateway-ig-extensions-ob/src/main/java/com/forgerock/sapi/gateway/ob/SecureApiGatewayObClassAliasResolver.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.forgerock.openig.alias.ClassAliasResolver;
 
 import com.forgerock.sapi.gateway.ob.consent.ConsentRequestAccessAuthorisationFilter;
+import com.forgerock.sapi.gateway.ob.consent.RepoApiErrorTransformFilter;
 import com.forgerock.sapi.gateway.ob.jws.signer.CompactSerializationJwsSigner;
 
 public class SecureApiGatewayObClassAliasResolver implements ClassAliasResolver {
@@ -29,6 +30,7 @@ public class SecureApiGatewayObClassAliasResolver implements ClassAliasResolver 
     static {
         ALIASES.put("ConsentRequestAccessAuthorisationFilter", ConsentRequestAccessAuthorisationFilter.class);
         ALIASES.put("CompactSerializationJwsSigner", CompactSerializationJwsSigner.class);
+        ALIASES.put("RepoApiErrorTransformFilter", RepoApiErrorTransformFilter.Heaplet.class);
     }
 
     /**

--- a/secure-api-gateway-ig-extensions-ob/src/main/java/com/forgerock/sapi/gateway/ob/consent/RepoApiErrorTransformFilter.java
+++ b/secure-api-gateway-ig-extensions-ob/src/main/java/com/forgerock/sapi/gateway/ob/consent/RepoApiErrorTransformFilter.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.consent;
+
+import static org.forgerock.http.protocol.Response.newResponsePromise;
+import static org.forgerock.http.protocol.Responses.newInternalServerError;
+import static org.forgerock.json.JsonValue.field;
+import static org.forgerock.json.JsonValue.fieldIfNotNull;
+import static org.forgerock.json.JsonValue.json;
+import static org.forgerock.json.JsonValue.object;
+
+import java.util.List;
+import java.util.Map;
+
+import org.forgerock.http.Filter;
+import org.forgerock.http.Handler;
+import org.forgerock.http.header.ContentTypeHeader;
+import org.forgerock.http.protocol.Request;
+import org.forgerock.http.protocol.Response;
+import org.forgerock.json.JsonValue;
+import org.forgerock.openig.heap.GenericHeaplet;
+import org.forgerock.openig.heap.HeapException;
+import org.forgerock.services.context.Context;
+import org.forgerock.util.promise.NeverThrowsException;
+import org.forgerock.util.promise.Promise;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Filter responsible for transforming RCS API error responses appropriately for OpenBanking use. Notably, RCS failures
+ * have the form:
+ * <pre>
+ * {@code
+ *     {
+ *       "errorMessage": "Request binding failed.",
+ *       "reason": "Null or empty redirect URL. Falling back to just throwing error back to UI"
+ *     }
+ * }
+ * </pre>
+ * <p>This is reformatted to OAuth2 expected error format with fields {@code error} and {@code error_description}.
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-5.2">RFC-6749, section 5.2</a>
+ */
+public class RepoApiErrorTransformFilter implements Filter {
+
+    private static final Logger logger = LoggerFactory.getLogger(RepoApiErrorTransformFilter.class);
+
+    private static final String LEGACY_ERROR_MESSAGE = "errorMessage";
+    private static final String OAUTH2_ERROR = "error";
+    private static final String OAUTH2_ERROR_DESCRIPTION = "error_description";
+    private static final String DEFAULT_OAUTH2_ERROR = "invalid_request_object";
+
+    // Map of AM error_description to transformed error.
+    private static final Map<String, String> ERROR_TRANSFORMS = Map.of(
+            "code_verifier parameter required", "invalid_grant",
+            "The redirection URI provided does not match a pre-registered value.", "invalid_request_object");
+
+    @Override
+    public Promise<Response, NeverThrowsException> filter(final Context context,
+                                                          final Request request,
+                                                          final Handler next) {
+        return next.handle(context, request)
+                   .thenAsync(response -> {
+                       if (!isApplicationJsonResponse(response)) {
+                           return newResponsePromise(response);
+                       }
+                       if (!response.getStatus().isClientError()) {
+                           return newResponsePromise(response);
+                       }
+                       return response.getEntity()
+                                      .getJsonAsync()
+                                      .then(JsonValue::json)
+                                      .then(errorResponseJson -> {
+                                          logger.debug("Response has a client error {}", response.getStatus());
+                                          response.getEntity()
+                                                  .setJson(transformErrorResponse(errorResponseJson));
+                                          return response;
+                                      }, ioe -> newInternalServerError());
+                   });
+    }
+
+    private static boolean isApplicationJsonResponse(final Response response) {
+        List<String> mediaTypes = response.getHeaders().getAll(ContentTypeHeader.NAME);
+        return mediaTypes.stream().anyMatch(mediaType -> mediaType.startsWith("application/json"));
+    }
+
+    private static JsonValue transformErrorResponse(final JsonValue errorResponseJson) {
+        JsonValue legacyErrorMessageJson = errorResponseJson.get(LEGACY_ERROR_MESSAGE);
+        JsonValue transformedErrorJson = json(object(
+                field(OAUTH2_ERROR, DEFAULT_OAUTH2_ERROR),
+                fieldIfNotNull(OAUTH2_ERROR_DESCRIPTION, legacyErrorMessageJson.asString())
+        ));
+        logger.debug("Transformed RCS API error from {} to {}", errorResponseJson, transformedErrorJson);
+        return transformedErrorJson;
+    }
+
+    /** Create a new {@link RepoApiErrorTransformFilter} in a heap environment. */
+    public static class Heaplet extends GenericHeaplet {
+        @Override
+        public Object create() {
+            return new RepoApiErrorTransformFilter();
+        }
+    }
+}

--- a/secure-api-gateway-ig-extensions-ob/src/test/java/com/forgerock/sapi/gateway/ob/consent/RepoApiErrorTransformFilterTest.java
+++ b/secure-api-gateway-ig-extensions-ob/src/test/java/com/forgerock/sapi/gateway/ob/consent/RepoApiErrorTransformFilterTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.consent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.forgerock.http.protocol.Status.BAD_REQUEST;
+import static org.forgerock.http.protocol.Status.INTERNAL_SERVER_ERROR;
+import static org.forgerock.http.protocol.Status.OK;
+import static org.forgerock.json.JsonValue.field;
+import static org.forgerock.json.JsonValue.json;
+import static org.forgerock.json.JsonValue.object;
+import static org.forgerock.util.promise.Promises.newResultPromise;
+
+import java.io.IOException;
+
+import org.forgerock.http.Handler;
+import org.forgerock.http.header.ContentTypeHeader;
+import org.forgerock.http.protocol.Request;
+import org.forgerock.http.protocol.Response;
+import org.forgerock.http.protocol.Status;
+import org.forgerock.json.JsonValue;
+import org.forgerock.services.context.RootContext;
+import org.junit.jupiter.api.Test;
+
+public class RepoApiErrorTransformFilterTest {
+
+    @Test
+    void shouldTransformResponseWithClientError() throws IOException {
+        // Given
+        final Response clientErrorResponse = new Response(BAD_REQUEST);
+        clientErrorResponse.getHeaders().put(ContentTypeHeader.NAME, "application/json");
+        clientErrorResponse.getEntity().setJson(json(object(field("errorMessage", "Invalid request"))));
+        Handler mockHandler = (context, request) -> newResultPromise(clientErrorResponse);
+        RepoApiErrorTransformFilter filter = new RepoApiErrorTransformFilter();
+        // When
+        Response response = filter.filter(new RootContext(), new Request(), mockHandler).getOrThrowIfInterrupted();
+        //Then
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST);
+        JsonValue responseJson = json(response.getEntity().getJson());
+        assertThat(responseJson.get("error").asString()).isEqualTo("invalid_request_object");
+        assertThat(responseJson.get("error_description").asString()).isEqualTo("Invalid request");
+    }
+
+    @Test
+    void shouldNotTransformResponseWithoutJsonContent() {
+        // Given
+        Response nonJsonResponse = new Response(BAD_REQUEST);
+        nonJsonResponse.getHeaders().put(ContentTypeHeader.NAME, "text/plain");
+        Handler mockHandler = (context, request) -> newResultPromise(nonJsonResponse);
+        RepoApiErrorTransformFilter filter = new RepoApiErrorTransformFilter();
+        // When
+        Response response = filter.filter(new RootContext(), new Request(), mockHandler).getOrThrowIfInterrupted();
+        // Then
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST);
+        assertThat(response.getHeaders().getFirst(ContentTypeHeader.NAME)).isEqualTo("text/plain");
+    }
+
+    @Test
+    void shouldNotTransformResponseWithoutClientError() throws IOException {
+        // Given
+        Response successResponse = new Response(Status.OK);
+        successResponse.getHeaders().put(ContentTypeHeader.NAME, "application/json");
+        successResponse.getEntity().setJson(json(object(field("meaning", 42))));
+        Handler mockHandler = (context, request) -> newResultPromise(successResponse);
+        RepoApiErrorTransformFilter filter = new RepoApiErrorTransformFilter();
+        // When
+        Response response = filter.filter(new RootContext(), new Request(), mockHandler).getOrThrowIfInterrupted();
+        // Then - response unchanged
+        assertThat(response.getStatus()).isEqualTo(OK);
+        assertThat(response.getHeaders().getFirst(ContentTypeHeader.NAME)).startsWith("application/json");
+        JsonValue responseJson = json(response.getEntity().getJson());
+        assertThat(responseJson.get("meaning").asInteger()).isEqualTo(42);
+    }
+
+    @Test
+    void shouldHandleInvalidJsonGracefully() {
+        // Given
+        Response invalidJsonResponse = new Response(BAD_REQUEST);
+        invalidJsonResponse.getHeaders().put(ContentTypeHeader.NAME, "application/json");
+        invalidJsonResponse.getEntity().setString("Invalid JSON");
+        Handler mockHandler = (context, request) -> newResultPromise(invalidJsonResponse);
+        RepoApiErrorTransformFilter filter = new RepoApiErrorTransformFilter();
+        // When
+        Response response = filter.filter(new RootContext(), new Request(), mockHandler).getOrThrowIfInterrupted();
+        // Then
+        assertThat(response.getStatus()).isEqualTo(INTERNAL_SERVER_ERROR);
+    }
+}


### PR DESCRIPTION
OPENIG-9515 Introduce error transform filter in route 83-rcs-api to ensure client errors are correctly reported according to OAuth2 standards.