### PR TITLE
Add null check for consentId in AuditConsent.groovy to skip audit if null

### DIFF
--- a/secure-api-gateway-fapi-pep-rs-ob-docker/src/main/resources/scripts/groovy/AuditConsent.groovy
+++ b/secure-api-gateway-fapi-pep-rs-ob-docker/src/main/resources/scripts/groovy/AuditConsent.groovy
@@ -29,7 +29,6 @@ next.handle(context, request)
             logger.info(SCRIPT_NAME + "No Content response, skipping audit")
             return
         }
-        logger.info(SCRIPT_NAME + context)
 
         def binding = new Binding()
         binding.response = response

--- a/secure-api-gateway-fapi-pep-rs-ob-docker/src/main/resources/scripts/groovy/AuditConsent.groovy
+++ b/secure-api-gateway-fapi-pep-rs-ob-docker/src/main/resources/scripts/groovy/AuditConsent.groovy
@@ -36,6 +36,11 @@ next.handle(context, request)
         binding.contexts = contexts
         consentId = new GroovyShell(binding).evaluate(consentIdLocator)
 
+        if (consentId == null) {
+            logger.info(SCRIPT_NAME + "Consent ID is null, skipping audit")
+            return
+        }
+
         contexts.accessAuditExtension.extendWith('ob-consent-id', consentId)
                                      .extendWith('ob-consent-role', role);
 


### PR DESCRIPTION
Ignore consent id when empty in order to avoid warn logging on audit extension.