### PR TITLE
OPENIG-10559 Build RS OB Docker Image nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,44 @@
+name: Nightly - Build and Deploy on Base Image Update
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 23 * * *'
+jobs:
+  check-base-image:
+    runs-on: ubuntu-22.04
+    name: Check Base Image Update
+    outputs:
+      updated-today: ${{ steps.check.outputs.updated }}
+    steps:
+      - name: Auth to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.DEV_GAR_KEY }}
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2.1.0
+      - name: Check if base image was updated today
+        id: check
+        run: |
+          TODAY=$(date -u +%Y-%m-%d)
+          IMAGE_DATE=$(gcloud container images list-tags gcr.io/forgerock-io/ig-fapi-pep-rs/docker-build \
+            --filter="tags:latest" \
+            --format="value(timestamp.datetime)" | cut -c1-10)
+          echo "Today (UTC): $TODAY"
+          echo "Image last updated (UTC): $IMAGE_DATE"
+          if [[ "$IMAGE_DATE" == "$TODAY" ]]; then
+            echo "Base image was updated today — triggering build"
+            echo "updated=true" >> $GITHUB_OUTPUT
+          else
+            echo "Base image was not updated today — skipping build"
+            echo "updated=false" >> $GITHUB_OUTPUT
+          fi
+  run_merge-template:
+    needs: check-base-image
+    if: needs.check-base-image.outputs.updated-today == 'true'
+    name: Merge - Build and Deploy
+    uses: SecureApiGateway/secure-api-gateway-ci/.github/workflows/reusable-merge.yml@main
+    secrets: inherit
+    with:
+      componentBranch: main
+      componentName: secure-api-gateway-fapi-pep-rs-ob
+      dockerTag: $(echo ${{ github.sha }} | cut -c1-7)


### PR DESCRIPTION
## Summary

The RS core image (`gcr.io/forgerock-io/ig-fapi-pep-rs/docker-build:latest`) is now built by the postcommit Jenkins pipeline inside `openig`. This image is used as a base image for RS OB Docker image — which is built on top of that core image — will not pick up core changes automatically on merge.

This PR adds a nightly GitHub Actions workflow that detects when the base image was updated and triggers a rebuild of the RS OB image.

## Changes

- **`.github/workflows/nightly.yml`** — new workflow that:
  - Runs on a cron schedule at 23:00 UTC every day (and supports manual `workflow_dispatch`)
  - Authenticates to GCP and checks whether `gcr.io/forgerock-io/ig-fapi-pep-rs/docker-build:latest` was pushed today
  - If the base image was updated today, triggers the reusable `secure-api-gateway-ci` merge workflow to build and push the RS OB image from `main`
  - Skips the build entirely when the base image has not changed, avoiding unnecessary rebuilds

## Jira

[OPENIG-10559](https://pingidentity.atlassian.net/browse/OPENIG-10559) — Build secure-api-gateway-fapi-pep-rs-ob docker image nightly