### PR TITLE
OPENIG-10559 Change the Nightly GitHub Action to be executed from Mon to Fri

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,39 +2,9 @@ name: Nightly - Build and Deploy on Base Image Update
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 23 * * *'
+    - cron: '0 5 * * 1-5'
 jobs:
-  check-base-image:
-    runs-on: ubuntu-22.04
-    name: Check Base Image Update
-    outputs:
-      updated-today: ${{ steps.check.outputs.updated }}
-    steps:
-      - name: Auth to GCP
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.DEV_GAR_KEY }}
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2.1.0
-      - name: Check if base image was updated today
-        id: check
-        run: |
-          TODAY=$(date -u +%Y-%m-%d)
-          IMAGE_DATE=$(gcloud container images list-tags gcr.io/forgerock-io/ig-fapi-pep-rs/docker-build \
-            --filter="tags:latest" \
-            --format="value(timestamp.datetime)" | cut -c1-10)
-          echo "Today (UTC): $TODAY"
-          echo "Image last updated (UTC): $IMAGE_DATE"
-          if [[ "$IMAGE_DATE" == "$TODAY" ]]; then
-            echo "Base image was updated today — triggering build"
-            echo "updated=true" >> $GITHUB_OUTPUT
-          else
-            echo "Base image was not updated today — skipping build"
-            echo "updated=false" >> $GITHUB_OUTPUT
-          fi
   run_merge-template:
-    needs: check-base-image
-    if: needs.check-base-image.outputs.updated-today == 'true'
     name: Merge - Build and Deploy
     uses: SecureApiGateway/secure-api-gateway-ci/.github/workflows/reusable-merge.yml@main
     secrets: inherit


### PR DESCRIPTION
Nightly job was executed every day, but it checks the timestamp of base image, if image was updated today, it rebuild the RS OB image. 

Unfortunately the timestamp of base image is not set properly - set to 1970, so it never meets the condition.
e.g.:
```
gcloud container images list-tags gcr.io/forgerock-io/ig-fapi-pep-rs/docker-build --filter="tags:latest" 
DIGEST        TAGS                                                                                 TIMESTAMP
8068dea6b841  2026.6.0-5562bd1afac7a55206b0f34e7d02cbda4ebb099f,2026.6.0-latest-postcommit,latest  1970-01-01T01:00:00
90c2a2fb1749  2026.9.0-f87b3e8ac679df215da733f74499f2d30afc348c,2026.9.0-latest-postcommit         1970-01-01T01:00:00
```

### Fix

Changed pipeline to run from Mon to Fri (no condition)