### PR TITLE
Update time when nightly pipeline is executed

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@ name: Nightly - Build and Deploy on Base Image Update
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 5 * * 1-5'
+    - cron: '0 1 * * 1-5'
 jobs:
   run_merge-template:
     name: Merge - Build and Deploy


### PR DESCRIPTION
The goal is to run this nightly pipeline before the deployment job will be triggered. Although it was set 5 am, the GitHub Actions pipelines shared the resources and builds can be delayed if many jobs are triggered. [This case has happened](https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-rs-ob/actions/runs/28505089923). To avoid id, change the trigger time to 1am